### PR TITLE
Change actor to be an HTTP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,3 @@ cython_debug/
 *inventory*.yml
 *env*.yml
 
-# Input and Output files (default names)
-input.json
-output.json

--- a/slack_server_mock/__main__.py
+++ b/slack_server_mock/__main__.py
@@ -1,16 +1,19 @@
 """ Application """
 import tornado
 
+from slack_server_mock.servers.actor.server import start_actor_server, stop_actor_server
 from slack_server_mock.servers.http.server import start_http_server, stop_http_server
 from slack_server_mock.servers.websocket.server import start_websocket_server, stop_websocket_server
 
 
 start_websocket_server()
 start_http_server()
+start_actor_server()
 try:
     tornado.ioloop.IOLoop.current().start()
 except KeyboardInterrupt:
     print("Shutting down")
 finally:
+    stop_actor_server()
     stop_http_server()
     stop_websocket_server()

--- a/slack_server_mock/actor/actor.py
+++ b/slack_server_mock/actor/actor.py
@@ -2,50 +2,51 @@
 import json
 
 from injector import inject, singleton
-from tornado.websocket import WebSocketHandler
-
-from slack_server_mock.settings.settings import Settings
+from tornado.locks import Event
+from tornado.websocket import WebSocketHandler, WebSocketClosedError
 
 
 @singleton
 class Actor():
     """ Slack Actor to send messages and log response """
     @inject
-    def __init__(self, settings: Settings) -> None:
-        self._conversation = self._load_inputs(settings.actor.input_file)
-        self._output = settings.actor.output_file
-        self._counter = 0
+    def __init__(self) -> None:
         self._websocket = None
+        self._event = Event()
+        self._response = None
 
     def app_connected(self, websocket: WebSocketHandler):
         """ Notify the actor that the application connected """
         self._websocket = websocket
-        self._websocket.write_message(self._wrap_message_with_envelope(self._conversation[0]['question']))
+
+    def app_disconnected(self):
+        """ Notify the actor that the application connected """
+        self._websocket = None
+
+    def is_app_connected(self):
+        """ Check if the application is connected """
+        return self._websocket is not None
+
+    async def _wait_for_response(self):
+        await self._event.wait()
+        response = self._response
+        self._response = None
+        return response
+
+    async def send_message(self, msg: str, wait_for_response=True) -> str:
+        """ Send a message to the application """
+        if not self.is_app_connected():
+            raise WebSocketClosedError()
+
+        self._websocket.write_message(self._wrap_message_with_envelope(msg))
+
+        return await self._wait_for_response() if wait_for_response else ""
 
     def message_received(self, msg: str):
-        """ Notify the actor that the application sent a message """
-        if self._websocket is None:
-            return
-        if self._counter >= len(self._conversation):
-            return
-        self._conversation[self._counter]['answer'] = msg
-        self._counter += 1
-        if self._counter < len(self._conversation):
-            self._websocket.write_message(
-                self._wrap_message_with_envelope(self._conversation[self._counter]['question'])
-            )
-        else:
-            self._dump_conversation()
-
-    def _dump_conversation(self):
-        with open(self._output, "+w", encoding="utf-8") as f:
-            json.dump(self._conversation, f)
-
-    @staticmethod
-    def _load_inputs(path: str):
-        with open(path, "r", encoding="utf-8") as f:
-            questions = json.load(f)
-        return [{"question": q} for q in questions]
+        """ Notify the actor that a message was received """
+        self._response = msg
+        self._event.set()
+        self._event.clear()
 
     @staticmethod
     def _wrap_message_with_envelope(msg: str):

--- a/slack_server_mock/servers/actor/handler.py
+++ b/slack_server_mock/servers/actor/handler.py
@@ -1,0 +1,38 @@
+""" Handlers for the Actor HTTP Server """
+from tornado.web import RequestHandler
+from tornado.websocket import WebSocketClosedError
+
+from slack_server_mock.actor.actor import Actor
+from slack_server_mock.injector.di import global_injector
+from slack_server_mock.servers.base_http_handlers import load_json_from_body
+
+
+class MessageHandler(RequestHandler):  # pylint: disable=W0223
+    """ Handler for the message endpoint """
+    async def post(self):
+        """ Handle post command """
+        data = load_json_from_body(self)
+        if not data:
+            return
+
+        msg = data.get('message')
+        if msg is None:
+            self.set_status(400)
+            self.write({"error": "JSON does not have a message key"})
+            return
+
+        try:
+            response = await global_injector.get(Actor).send_message(msg)
+        except WebSocketClosedError:
+            self.set_status(400)
+            self.write({"error": "The application is not connected"})
+            return
+
+        self.write({"answer:": response})
+
+
+class ConnectedHandler(RequestHandler):  # pylint: disable=W0223
+    """ Handler for the connected endpoint """
+    def get(self):
+        """ Handle get command """
+        self.write({"connected": global_injector.get(Actor).is_app_connected()})

--- a/slack_server_mock/servers/actor/server.py
+++ b/slack_server_mock/servers/actor/server.py
@@ -1,0 +1,33 @@
+""" Actor HTTP Server """
+from injector import inject, singleton
+from tornado.web import Application
+
+
+from slack_server_mock.injector.di import global_injector
+from slack_server_mock.settings.settings import Settings
+from slack_server_mock.servers.base_http_server import BaseHTTPServer
+from slack_server_mock.servers.actor import handler
+
+
+@singleton
+class ActorHTTPServer(BaseHTTPServer):
+    """ Mock Implementation of the Slack HTTP server """
+    @inject
+    def __init__(self, settings: Settings) -> None:
+        app = Application(
+            [
+                (r"/connected", handler.ConnectedHandler),
+                (r"/message", handler.MessageHandler),
+            ]
+        )
+        super().__init__(app, settings.actor.port)
+
+
+def start_actor_server():
+    """ Static method for starting the HTTP Server """
+    global_injector.get(ActorHTTPServer).run()
+
+
+def stop_actor_server():
+    """ Static method for stopping the HTTP Server """
+    global_injector.get(ActorHTTPServer).stop()

--- a/slack_server_mock/servers/base_http_handlers.py
+++ b/slack_server_mock/servers/base_http_handlers.py
@@ -1,0 +1,15 @@
+""" Common code for HTTP Handlers """
+import json
+
+from tornado.web import RequestHandler
+
+
+def load_json_from_body(handler: RequestHandler):
+    """ Load JSON from request body """
+    try:
+        data = json.loads(handler.request.body)
+    except json.JSONDecodeError:
+        handler.set_status(400)
+        handler.write({"error": "Invalid JSON"})
+        return None
+    return data

--- a/slack_server_mock/servers/base_http_server.py
+++ b/slack_server_mock/servers/base_http_server.py
@@ -1,0 +1,20 @@
+""" Actor HTTP Server """
+from tornado.httpserver import HTTPServer
+from tornado.web import Application
+
+
+class BaseHTTPServer():
+    """ Mock Implementation of the Slack HTTP server """
+    def __init__(self, app: Application, port: int) -> None:
+        self._http_server = HTTPServer(app)
+        self._port = port
+
+    def run(self):
+        """ Start the HTTP Server """
+        print(f"HTTP server running on port {self._port}")
+        self._http_server.listen(self._port)
+
+    def stop(self):
+        """ Stop the HTTP Server """
+        self._http_server.stop()
+        print("HTTP server shutdown")

--- a/slack_server_mock/servers/http/handler.py
+++ b/slack_server_mock/servers/http/handler.py
@@ -1,12 +1,12 @@
 """ HTTP Handler """
 from datetime import datetime
-import json
 import re
 
 from tornado.web import RequestHandler
 
 from slack_server_mock.actor.actor import Actor
 from slack_server_mock.injector.di import global_injector
+from slack_server_mock.servers.base_http_handlers import load_json_from_body
 from slack_server_mock.settings.settings import Settings
 
 
@@ -91,13 +91,10 @@ class ApiTestHandler(BaseSlackHandler):  # pylint: disable=W0223
     def post(self):
         """ Handle post request """
         if self._is_request_valid():
-            try:
-                data = json.loads(self.request.body)
-                if data:
-                    self.write({"ok": True, "args": data})
-            except json.JSONDecodeError:
-                self.set_status(400)
-                self.write({"error": "Invalid JSON"})
+            data = load_json_from_body(self)
+            if not data:
+                return
+            self.write({"ok": True, "args": data})
 
 
 class ChatPostMessageHandler(BaseSlackHandler):  # pylint: disable=W0223
@@ -106,11 +103,8 @@ class ChatPostMessageHandler(BaseSlackHandler):  # pylint: disable=W0223
     def post(self):
         """ Handle post request """
         if self._is_request_valid():
-            try:
-                data = json.loads(self.request.body)
-            except json.JSONDecodeError:
-                self.set_status(400)
-                self.write({"error": "Invalid JSON"})
+            data = load_json_from_body(self)
+            if not data:
                 return
 
             global_injector.get(Actor).message_received(data['text'])

--- a/slack_server_mock/servers/http/server.py
+++ b/slack_server_mock/servers/http/server.py
@@ -1,20 +1,19 @@
 """ HTTP Server """
 from injector import inject, singleton
-from tornado.httpserver import HTTPServer
 from tornado.web import Application
 
 
 from slack_server_mock.injector.di import global_injector
 from slack_server_mock.settings.settings import Settings
+from slack_server_mock.servers.base_http_server import BaseHTTPServer
 from slack_server_mock.servers.http import handler
 
 
 @singleton
-class SlackHTTPServer():
+class SlackHTTPServer(BaseHTTPServer):
     """ Mock Implementation of the Slack HTTP server """
     @inject
     def __init__(self, settings: Settings) -> None:
-        self._port = settings.http_server.port
         app = Application(
             [
                 (r"/auth.test", handler.AuthTestHandler),
@@ -23,17 +22,7 @@ class SlackHTTPServer():
                 (r"/chat.postMessage", handler.ChatPostMessageHandler)
             ]
         )
-        self._http_server = HTTPServer(app)
-
-    def run(self):
-        """ Start the HTTP Server """
-        print(f"HTTP server running on port {self._port}")
-        self._http_server.listen(self._port)
-
-    def stop(self):
-        """ Stop the HTTP Server """
-        self._http_server.stop()
-        print("HTTP server shutdown")
+        super().__init__(app, settings.http_server.port)
 
 
 def start_http_server():

--- a/slack_server_mock/servers/websocket/handler.py
+++ b/slack_server_mock/servers/websocket/handler.py
@@ -15,3 +15,4 @@ class SlackWebSocketHandler(WebSocketHandler):
 
     def on_close(self):
         print("WebSocket closed")
+        global_injector.get(Actor).app_disconnected()

--- a/slack_server_mock/settings/settings.py
+++ b/slack_server_mock/settings/settings.py
@@ -22,13 +22,9 @@ class WebSocketServer(BaseModel):
 
 class Actor(BaseModel):
     """ Settings for the Actor """
-    input_file: str = Field(
-        "./input.json",
-        description="Input file containing message to send to the application"
-    )
-    output_file: str = Field(
-        "./output.json",
-        description="Output file to store the messages received from the application"
+    port: int = Field(
+        8080,
+        description="Actor HTTP Server Listening port"
     )
 
 


### PR DESCRIPTION
Create BaseHTTPServer to avoid code duplication
Adjust the current HTTP server
Create another HTTP server with settings for port
The message handler sends the message and returns the response 
The actor now gets messages from the HTTP server and returns the next message as a response