### PR TITLE
Add support for static response data in mock Slack server 

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -34,6 +34,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r test/requirements.txt
+        pip install -e .
 
     - name: Run tests
       run: |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ At minimum, each entry must have a name and an ID.
 
 In the `settings.yaml` file, set `slack_server.channels_path` to the location of the file.
 
+#### Response Data Configuration
+The `settings.yaml` file contains a `response_data` section that allows you to configure the responses of the server for specific endpoints.
+
+The responses definied in the `response_data` section are JSON files that contain the response data for the endpoint.
+
+The directory structure should be as follows:
+```
+response_data_path
+  / endpoint_name
+    / ID-VALUE.json
+```
+See the `test/responses` directory for examples.
+
+For endpoints with multiple query parameters, the file should be named with the query parameters separated by a dash. For example, `conversations.history/channel-ts.json`.
+
+In the `settings.yaml` file, set the `response_data` section to the base path for the JSON files.
+
 ### Using Poetry
 
 #### Prerequisites

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,2 +1,3 @@
-slack_server: {}
+slack_server:
+  response_data_path: test/responses/
 actor: {}

--- a/slack_server_mock/__main__.py
+++ b/slack_server_mock/__main__.py
@@ -1,16 +1,22 @@
 """ Application """
+import logging
+import os
+
 import tornado
 
 from slack_server_mock.servers.actor.server import start_actor_server, stop_actor_server
 from slack_server_mock.slack_server.slack_server import start_slack_server, stop_slack_server
 
 
+logging.basicConfig(
+    level=logging.DEBUG if os.environ.get('DEBUG') else logging.INFO,
+    format='%(asctime)s - %(name)42s - %(levelname)7s - %(message)s')
 start_slack_server()
 start_actor_server()
 try:
     tornado.ioloop.IOLoop.current().start()
 except KeyboardInterrupt:
-    print("Shutting down")
+    LOGGER.info("Shutting down")
 finally:
     stop_actor_server()
     stop_slack_server()

--- a/slack_server_mock/__main__.py
+++ b/slack_server_mock/__main__.py
@@ -7,6 +7,7 @@ import tornado
 from slack_server_mock.servers.actor.server import start_actor_server, stop_actor_server
 from slack_server_mock.slack_server.slack_server import start_slack_server, stop_slack_server
 
+LOGGER = logging.getLogger(__name__)
 
 logging.basicConfig(
     level=logging.DEBUG if os.environ.get('DEBUG') else logging.INFO,

--- a/slack_server_mock/servers/base_http_server.py
+++ b/slack_server_mock/servers/base_http_server.py
@@ -10,6 +10,7 @@ LOGGER = logging.getLogger(__name__)
 class BaseHTTPServer():
     """ Mock Implementation of the Slack HTTP server """
     def __init__(self, app: Application, port: int) -> None:
+        self._app = app
         self._http_server = HTTPServer(app)
         self._port = port
 

--- a/slack_server_mock/servers/base_http_server.py
+++ b/slack_server_mock/servers/base_http_server.py
@@ -1,6 +1,10 @@
-""" Actor HTTP Server """
+"""Base HTTP Server """
+import logging
+
 from tornado.httpserver import HTTPServer
 from tornado.web import Application
+
+LOGGER = logging.getLogger(__name__)
 
 
 class BaseHTTPServer():
@@ -11,10 +15,10 @@ class BaseHTTPServer():
 
     def run(self):
         """ Start the HTTP Server """
-        print(f"HTTP server running on port {self._port}")
+        LOGGER.info('HTTP server running on port %i', self._port)
         self._http_server.listen(self._port)
 
     def stop(self):
         """ Stop the HTTP Server """
         self._http_server.stop()
-        print("HTTP server shutdown")
+        LOGGER.info('HTTP server on port %i shutdown', self._port)

--- a/slack_server_mock/servers/http/server.py
+++ b/slack_server_mock/servers/http/server.py
@@ -21,8 +21,12 @@ class SlackHTTPServer(BaseHTTPServer):
                 (r"/api.test", handler.ApiTestHandler),
                 (r"/chat.postMessage", handler.ChatPostMessageHandler),
                 (r"/chat.postEphemeral", handler.ChatPostEphemeralHandler),
+                (r"/conversations.history", handler.ConversationsHistoryHandler),
+                (r"/conversations.info", handler.ConversationsInfoHandler),
                 (r"/conversations.join", handler.ConversationsJoinHandler),
                 (r"/conversations.list", handler.ConversationsListHandler),
+                (r"/conversations.replies", handler.ConversationsRepliesHandler),
+                (r"/users.info", handler.UsersInfoHandler),
             ]
         )
         super().__init__(app, settings.slack_server.http_port)

--- a/slack_server_mock/servers/websocket/handler.py
+++ b/slack_server_mock/servers/websocket/handler.py
@@ -1,18 +1,22 @@
+import logging
+
 from tornado.websocket import WebSocketHandler
 
 from slack_server_mock.actor.actor import Actor
 from slack_server_mock.injector.di import global_injector
 
+LOGGER = logging.getLogger(__name__)
+
 
 # Define WebSocket handler
 class SlackWebSocketHandler(WebSocketHandler):
     def open(self):
-        print("WebSocket opened")
+        LOGGER.info("WebSocket opened")
         global_injector.get(Actor).app_connected(self)
 
     def on_message(self, message):
-        print("Received message:", message)
+        LOGGER.info("Received message:", message)
 
     def on_close(self):
-        print("WebSocket closed")
+        LOGGER.info("WebSocket closed")
         global_injector.get(Actor).app_disconnected()

--- a/slack_server_mock/servers/websocket/server.py
+++ b/slack_server_mock/servers/websocket/server.py
@@ -1,4 +1,6 @@
 """ WebSocket Server """
+import logging
+
 from injector import inject, singleton
 from tornado.httpserver import HTTPServer
 from tornado.web import Application
@@ -6,6 +8,8 @@ from tornado.web import Application
 from slack_server_mock.actor.actor import Actor
 from slack_server_mock.servers.websocket import handler
 from slack_server_mock.settings.settings import Settings
+
+LOGGER = logging.getLogger(__name__)
 
 
 @singleton
@@ -24,10 +28,10 @@ class SlackWebSocketServer():
 
     def run(self):
         """ Start the HTTP Server """
-        print(f"WebSocket server running on port {self._port}")
+        LOGGER.info("WebSocket server running on port %i", self._port)
         self._ws_server.listen(self._port)
 
     def stop(self):
         """ Stop the HTTP Server """
         self._ws_server.stop()
-        print(f"WebSocket server shutdown")
+        LOGGER.info("WebSocket server shutdown")

--- a/slack_server_mock/settings/settings.py
+++ b/slack_server_mock/settings/settings.py
@@ -8,17 +8,22 @@ class SlackServer(BaseModel):
     """ Slack Server """
     http_port: int = Field(
         8888,
-        description="HTTP Server Listening port"
+        description="Mock Slack HTTP Server Listening port"
     )
 
     websocket_port: int = Field(
         3001,
-        description="HTTP Server Listening port"
+        description="Mock Slack Websocket Server Listening port"
     )
 
     channels_path: str = Field(
         None,
         description="Path to a file containing the list of conversations"
+    )
+
+    response_data_path: str = Field(
+        None,
+        description="Path to a directory structure containing response replies"
     )
 
 

--- a/slack_server_mock/slack_server/slack_server.py
+++ b/slack_server_mock/slack_server/slack_server.py
@@ -1,5 +1,7 @@
 """ Slack Mock Server """
 import json
+import logging
+import pathlib
 
 from injector import inject, singleton
 
@@ -7,6 +9,8 @@ from slack_server_mock.injector.di import global_injector
 from slack_server_mock.settings.settings import Settings
 from slack_server_mock.servers.http.server import SlackHTTPServer
 from slack_server_mock.servers.websocket.server import SlackWebSocketServer
+
+LOGGER = logging.getLogger(__name__)
 
 
 @singleton
@@ -22,11 +26,17 @@ class SlackServer():
         self._http_server = http_server
         self._websocket_server = websocket_server
         self._channels = self._load_channels(settings.slack_server.channels_path)
+        self._response_data = self._load_response_data(pathlib.Path(settings.slack_server.response_data_path))
 
     @property
     def channels(self):
         """ Return the channels list """
         return self._channels
+
+    @property
+    def response_data(self):
+        """ Return the mock response data """
+        return self._response_data
 
     def start(self):
         """ Start the Slack server """
@@ -39,14 +49,31 @@ class SlackServer():
         self._websocket_server.stop()
 
     @staticmethod
-    def _load_channels(path):
+    def _load_channels(path: str):
         channels = []
         if path:
-            with open(path, "r", encoding="utf-8") as f:
-                channels = json.load(f)
+            path = pathlib.Path(path)
+            if path.exists():
+                with path.open("r", encoding="utf-8") as f:
+                    channels = json.load(f)
         if not isinstance(channels, list):
             raise ValueError("The content of the channels file is not a JSON array")
         return channels
+
+    @staticmethod
+    def _load_response_data(path: pathlib.Path):
+        response_data = {}
+        if path:
+            path = pathlib.Path(path)
+            if path.exists():
+                for file in path.glob("**/*.json"):
+                    endpoint = str(file.parent).split('/', maxsplit=10)[-1]
+                    if endpoint not in response_data:
+                        response_data[endpoint] = {}
+                    with file.open("r", encoding="utf-8") as f:
+                        response_data[endpoint][file.stem] = json.load(f)
+                    LOGGER.info('Loaded Endpoint %s: %s', endpoint, file.stem)
+        return response_data
 
 
 def start_slack_server():

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,4 @@
 slack_bolt
 pytest
 requests
+tornado

--- a/test/responses/conversations.history/c012ab3cd-1512085950.000216.json
+++ b/test/responses/conversations.history/c012ab3cd-1512085950.000216.json
@@ -1,0 +1,22 @@
+{
+  "ok": true,
+  "messages": [
+    {
+      "type": "message",
+      "user": "U123ABC456",
+      "text": "I find you punny and would like to smell your nose letter",
+      "ts": "1512085950.000216"
+    },
+    {
+      "type": "message",
+      "user": "U222BBB222",
+      "text": "What, you want to smell my shoes better?",
+      "ts": "1512104434.000490"
+    }
+  ],
+  "has_more": true,
+  "pin_count": 0,
+  "response_metadata": {
+    "next_cursor": "bmV4dF90czoxNTEyMDg1ODYxMDAwNTQz"
+  }
+}

--- a/test/responses/conversations.info/c012ab3cd.json
+++ b/test/responses/conversations.info/c012ab3cd.json
@@ -1,0 +1,59 @@
+{
+  "ok": true,
+  "channel": {
+    "id": "C012AB3CD",
+    "name": "general",
+    "is_channel": true,
+    "is_group": false,
+    "is_im": false,
+    "is_mpim": false,
+    "is_private": false,
+    "created": 1654868334,
+    "is_archived": false,
+    "is_general": true,
+    "unlinked": 0,
+    "name_normalized": "general",
+    "is_shared": false,
+    "is_frozen": false,
+    "is_org_shared": false,
+    "is_pending_ext_shared": false,
+    "pending_shared": [],
+    "context_team_id": "T123ABC456",
+    "updated": 1723130875818,
+    "parent_conversation": null,
+    "creator": "U123ABC456",
+    "is_ext_shared": false,
+    "shared_team_ids": ["T123ABC456"],
+    "pending_connected_team_ids": [],
+    "topic": {
+      "value": "For public discussion of generalities",
+      "creator": "W012A3BCD",
+      "last_set": 1449709364
+    },
+    "purpose": {
+      "value": "This part of the workspace is for fun. Make fun here.",
+      "creator": "W012A3BCD",
+      "last_set": 1449709364
+    },
+    "properties": {
+      "tabs": [
+        {
+          "id": "workflows",
+          "label": "",
+          "type": "workflows"
+        },
+        {
+          "id": "files",
+          "label": "",
+          "type": "files"
+        },
+        {
+          "id": "bookmarks",
+          "label": "",
+          "type": "bookmarks"
+        }
+      ]
+    },
+    "previous_names": []
+  }
+}

--- a/test/responses/conversations.info/c012ab3ce.json
+++ b/test/responses/conversations.info/c012ab3ce.json
@@ -1,0 +1,22 @@
+{
+  "ok": true,
+  "channel": {
+    "id": "C012AB3CD",
+    "created": 1507235627,
+    "is_im": true,
+    "is_org_shared": false,
+    "user": "U27FFLNF4",
+    "last_read": "1513718191.000038",
+    "latest": {
+      "type": "message",
+      "user": "U5R3PALPN",
+      "text": "Psssst!",
+      "ts": "1513718191.000038"
+    },
+    "unread_count": 0,
+    "unread_count_display": 0,
+    "is_open": true,
+    "locale": "en-US",
+    "priority": 0.043016851216706
+  }
+}

--- a/test/responses/conversations.replies/c012ab3cd-1512085950.000216.json
+++ b/test/responses/conversations.replies/c012ab3cd-1512085950.000216.json
@@ -1,0 +1,44 @@
+{
+  "messages": [
+    {
+      "type": "message",
+      "user": "U061F7AUR",
+      "text": "island",
+      "thread_ts": "1482960137.003543",
+      "reply_count": 3,
+      "subscribed": true,
+      "last_read": "1484678597.521003",
+      "unread_count": 0,
+      "ts": "1482960137.003543"
+    },
+    {
+      "type": "message",
+      "user": "U061F7AUR",
+      "text": "one island",
+      "thread_ts": "1482960137.003543",
+      "parent_user_id": "U061F7AUR",
+      "ts": "1483037603.017503"
+    },
+    {
+      "type": "message",
+      "user": "U061F7AUR",
+      "text": "two island",
+      "thread_ts": "1482960137.003543",
+      "parent_user_id": "U061F7AUR",
+      "ts": "1483051909.018632"
+    },
+    {
+      "type": "message",
+      "user": "U061F7AUR",
+      "text": "three for the land",
+      "thread_ts": "1482960137.003543",
+      "parent_user_id": "U061F7AUR",
+      "ts": "1483125339.020269"
+    }
+  ],
+  "has_more": true,
+  "ok": true,
+  "response_metadata": {
+    "next_cursor": "bmV4dF90czoxNDg0Njc4MjkwNTE3MDkx"
+  }
+}

--- a/test/responses/users.info/w012a3cde.json
+++ b/test/responses/users.info/w012a3cde.json
@@ -1,0 +1,41 @@
+{
+  "ok": true,
+  "user": {
+    "id": "W012A3CDE",
+    "team_id": "T012AB3C4",
+    "name": "spengler",
+    "deleted": false,
+    "color": "9f69e7",
+    "real_name": "Egon Spengler",
+    "tz": "America/Los_Angeles",
+    "tz_label": "Pacific Daylight Time",
+    "tz_offset": -25200,
+    "profile": {
+      "avatar_hash": "ge3b51ca72de",
+      "status_text": "Print is dead",
+      "status_emoji": ":books:",
+      "real_name": "Egon Spengler",
+      "display_name": "spengler",
+      "real_name_normalized": "Egon Spengler",
+      "display_name_normalized": "spengler",
+      "email": "spengler@ghostbusters.example.com",
+      "image_original": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+      "image_24": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+      "image_32": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+      "image_48": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+      "image_72": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+      "image_192": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+      "image_512": "https://.../avatar/e3b51ca72dee4ef87916ae2b9240df50.jpg",
+      "team": "T012AB3C4"
+    },
+    "is_admin": true,
+    "is_owner": false,
+    "is_primary_owner": false,
+    "is_restricted": false,
+    "is_ultra_restricted": false,
+    "is_bot": false,
+    "updated": 1502138686,
+    "is_app_user": false,
+    "has_2fa": false
+  }
+}

--- a/test/test_handler.py
+++ b/test/test_handler.py
@@ -1,0 +1,99 @@
+import json
+import pathlib
+
+from tornado import testing
+
+from slack_server_mock.slack_server.slack_server import start_slack_server, stop_slack_server, SlackServer
+from slack_server_mock.injector.di import global_injector
+
+
+DATA_DIR = pathlib.Path(__file__).parent / 'responses'
+
+
+class TestBaseSlackHandler(testing.AsyncHTTPTestCase):
+
+    DEFAULT_HEADERS = {
+        'Authorization': 'Bearer xoxb-foo',
+        'User-Agent': 'python/slackclient/1.3.0'
+    }
+
+    def setUp(self):
+        super().setUp()
+        start_slack_server()
+        stop_slack_server()
+
+    def get_app(self):
+        return global_injector.get(SlackServer)._http_server._app
+
+    def test_auth_test(self):
+        expectation = b'{"ok": false, "error": "invalid_auth"}'
+        response = self.fetch('/auth.test')
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body, expectation)
+
+    def test_conversations_history(self):
+        for file in DATA_DIR.glob('conversations.history/*.json'):
+            with file.open() as handle:
+                expectation = json.load(handle)
+            channel, oldest = file.stem.split('-')
+            response = self.fetch(f'/conversations.history?channel={channel}&oldest={oldest}',
+                                  headers=self.DEFAULT_HEADERS)
+            self.assertEqual(response.code, 200)
+            self.assertEqual(response.headers['Content-Type'], 'application/json; charset=UTF-8')
+            self.assertDictEqual(json.loads(response.body), expectation)
+
+    def test_conversations_history_404(self):
+        expectation = {"ok": False, "error": "channel_not_found"}
+        response = self.fetch(f'/conversations.history?channel=c012ab3cd&oldest=12345', headers=self.DEFAULT_HEADERS)
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.headers['Content-Type'], 'application/json; charset=UTF-8')
+        self.assertDictEqual(json.loads(response.body), expectation)
+
+    def test_conversations_info(self):
+        for file in DATA_DIR.glob('conversations.info/*.json'):
+            with file.open() as handle:
+                expectation = json.load(handle)
+            response = self.fetch(f'/conversations.info?channel={file.stem}', headers=self.DEFAULT_HEADERS)
+            self.assertEqual(response.code, 200)
+            self.assertEqual(response.headers['Content-Type'], 'application/json; charset=UTF-8')
+            self.assertDictEqual(json.loads(response.body), expectation)
+
+    def test_conversations_info_404(self):
+        expectation = {"ok": False, "error": "channel_not_found"}
+        response = self.fetch(f'/conversations.info?channel=c12345', headers=self.DEFAULT_HEADERS)
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.headers['Content-Type'], 'application/json; charset=UTF-8')
+        self.assertDictEqual(json.loads(response.body), expectation)
+
+    def test_conversations_replies(self):
+        for file in DATA_DIR.glob('conversations.replies/*.json'):
+            with file.open() as handle:
+                expectation = json.load(handle)
+            channel, ts = file.stem.split('-')
+            response = self.fetch(f'/conversations.replies?channel={channel}&ts={ts}', headers=self.DEFAULT_HEADERS)
+            self.assertEqual(response.code, 200)
+            self.assertEqual(response.headers['Content-Type'], 'application/json; charset=UTF-8')
+            self.assertDictEqual(json.loads(response.body), expectation)
+
+    def test_conversations_replies_404(self):
+        expectation = {"ok": False, "error": "thread_not_found"}
+        response = self.fetch(f'/conversations.replies?channel=c12345&ts=1234', headers=self.DEFAULT_HEADERS)
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.headers['Content-Type'], 'application/json; charset=UTF-8')
+        self.assertDictEqual(json.loads(response.body), expectation)
+
+    def test_users_info(self):
+        for file in DATA_DIR.glob('users.info/*.json'):
+            with file.open() as handle:
+                expectation = json.load(handle)
+            response = self.fetch(f'/users.info?user={file.stem}', headers=self.DEFAULT_HEADERS)
+            self.assertEqual(response.code, 200)
+            self.assertEqual(response.headers['Content-Type'], 'application/json; charset=UTF-8')
+            self.assertDictEqual(json.loads(response.body), expectation)
+
+    def test_users_info_404(self):
+        expectation = {"ok": False, "error": "user_not_found"}
+        response = self.fetch(f'/users.info?user=w12345', headers=self.DEFAULT_HEADERS)
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.headers['Content-Type'], 'application/json; charset=UTF-8')
+        self.assertDictEqual(json.loads(response.body), expectation)


### PR DESCRIPTION
Introduced a framework for serving static mock responses for specific Slack API endpoints using JSON files. Updated server infrastructure, handlers, and settings configuration to support this functionality, including `response_data_path` and appropriate endpoint routing. Enhanced the documentation with details on configuring and structuring response data.

This allowed me to easily add in endpoints for `conversations.history`, `conversations.info`, `conversations.replies`, and `users.info` which I needed for my testing.

In addition, I refactored a little to use logging instead of print statements, as it would have been helpful to debug my initial issues in getting up and running.

Finally I removed a little bit of duplicate Tornado RequestHandler code by moving request validation to `prepare()` method, ensuring all requests are validated upfront. This eliminates redundant validation checks in `get()` and `post()` methods and simplifies handler logic.

Let me know if you'd like to see any changes.